### PR TITLE
add Dockerfile to support OpenROAD unified build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+Dockerfile
+.dockerignore
+
+# from .gitignore
+*.o
+*.a
+*.lo
+*.la
+*.gcov
+*.gcda
+*.gcno
+*.rej
+*.orig
+TAGS
+*~
+\#*#
+.~lock.*#
+.DS_Store
+Makefile
+
+/build
+/test/results
+
+ResizerTclInitVar.cc
+Resizer_wrap.cc
+ResizerConfig.hh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 Dockerfile
 .dockerignore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM centos:centos6 AS builder
+
+# install gcc 6
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-6 devtoolset-6-libatomic-devel
+ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc \
+    CPP=/opt/rh/devtoolset-6/root/usr/bin/cpp \
+    CXX=/opt/rh/devtoolset-6/root/usr/bin/g++ \
+    PATH=/opt/rh/devtoolset-6/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:/opt/rh/devtoolset-6/root/usr/lib64/dyninst:/opt/rh/devtoolset-6/root/usr/lib/dyninst:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:$LD_LIBRARY_PATH
+
+# install dependencies
+RUN yum install -y wget git zlib-devel tcl-devel swig bison flex
+
+# Installing cmake for build dependency
+RUN wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh && \
+    chmod +x cmake-3.9.0-Linux-x86_64.sh  && \
+    ./cmake-3.9.0-Linux-x86_64.sh --skip-license --prefix=/usr/local
+
+# download CUDD
+RUN wget https://www.davidkebo.com/source/cudd_versions/cudd-3.0.0.tar.gz && \
+    tar -xvf cudd-3.0.0.tar.gz && \
+    cd cudd-3.0.0 && \
+    ./configure && \
+    make && \
+    make install
+
+COPY . /Resizer
+RUN mkdir /Resizer/build
+WORKDIR /Resizer/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/build -DCUDD=/usr/local ..
+RUN make
+
+# Run enviornment
+FROM centos:centos6 AS runner
+RUN yum update -y && yum install -y tcl-devel
+COPY --from=builder /Resizer/build/resizer /build/resizer
+COPY --from=builder /Resizer/build/verilog2def /build/verilog2def
+RUN useradd -ms /bin/bash openroad
+USER openroad
+WORKDIR /home/openroad


### PR DESCRIPTION
This pull request adds a Dockerfile to the repository to integrate in the unified build environment. The image is based on centos6, which is the agreed build environment for OpenROAD.

To build:
`docker build -t <image_name> .`

Binaries are in `/build` directory, which can also be run from within the container.